### PR TITLE
Only allow user uses legal characters in password of vyos

### DIFF
--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vyos/VyosVmFactory.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vyos/VyosVmFactory.java
@@ -171,8 +171,8 @@ public class VyosVmFactory extends VirtualRouterApplianceVmFactory implements Co
         VirtualRouterGlobalConfig.VYOS_PASSWORD.installValidateExtension(new GlobalConfigValidatorExtensionPoint() {
             @Override
             public void validateGlobalConfig(String category, String name, String oldValue, String newValue) throws GlobalConfigException {
-                if (newValue.isEmpty()) {
-                    throw new GlobalConfigException("the vyos password cannot be an empty string");
+                if (!newValue.matches("[A-Za-z0-9-$@!%*#?&_]{1,}")) {
+                    throw new GlobalConfigException("the vrouter password can only contain alphabet, number and these special character: -$@!%*#?&_");
                 }
             }
         });


### PR DESCRIPTION
Now only users use alphabet, number and these special character: -$@!%*#?&_

For zxwing/premium#1523