### PR TITLE
Fix bug that allow user allocate network and broadcast address

### DIFF
--- a/network/src/main/java/org/zstack/network/l3/L3NetworkApiInterceptor.java
+++ b/network/src/main/java/org/zstack/network/l3/L3NetworkApiInterceptor.java
@@ -244,6 +244,12 @@ public class L3NetworkApiInterceptor implements ApiMessageInterceptor {
             ));
         }
 
+        if (ipr.getStartIp().equals(info.getNetworkAddress()) || ipr.getEndIp().equals(info.getBroadcastAddress())){
+            throw new ApiMessageInterceptionException((errf.instantiateErrorCode(SysErrors.INVALID_ARGUMENT_ERROR,
+                    "ip allocation can not contain network address or broadcast address")
+            ));
+        }
+
         long startip = NetworkUtils.ipv4StringToLong(ipr.getStartIp());
         long endip = NetworkUtils.ipv4StringToLong(ipr.getEndIp());
         if (startip > endip) {


### PR DESCRIPTION
When user create l3 network via IP range, it allows allocate network
and broadcast address, and this patch fix it.

For zxwing/premium#1685