### PR TITLE
Fix lb listener delete not work

### DIFF
--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerBase.java
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerBase.java
@@ -722,10 +722,10 @@ public class LoadBalancerBase {
 
     private LoadBalancerStruct removeListenerStruct(LoadBalancerListenerInventory listener) {
         LoadBalancerStruct s = makeStruct();
-        Iterator<LoadBalancerListenerInventory> it = s.getListeners().iterator();
-        while (it.hasNext()) {
-            if (it.next().getUuid().equals(listener.getUuid())) {
-                it.remove();
+
+        for (LoadBalancerListenerInventory l : s.getListeners()) {
+            if (l.getUuid().equals(listener.getUuid())) {
+                l.setVmNicRefs(new ArrayList<>());
             }
         }
         return s;

--- a/test/src/test/java/org/zstack/test/lb/TestVirtualRouterLb5.java
+++ b/test/src/test/java/org/zstack/test/lb/TestVirtualRouterLb5.java
@@ -135,14 +135,14 @@ public class TestVirtualRouterLb5 {
         Assert.assertNull(listenerVO);
         Assert.assertFalse(vconfig.refreshLbCmds.isEmpty());
         cmd = vconfig.refreshLbCmds.get(0);
-        Assert.assertEquals(1, cmd.getLbs().size());
+        Assert.assertEquals(2, cmd.getLbs().size());
         to = CollectionUtils.find(cmd.getLbs(), new Function<LbTO, LbTO>() {
             @Override
             public LbTO call(LbTO arg) {
                 return arg.getInstancePort() == 100 ? arg : null;
             }
         });
-        Assert.assertNull(to);
+        Assert.assertNotNull(to);
 
         listener1 = api.createLoadBalancerListener(listener1, null);
         vconfig.refreshLbSuccess = false;


### PR DESCRIPTION
When delete a listener, we need to remove listener's nic
instead of remove the listener in command.

For zxwing/premium#1596