### PR TITLE
Fix VirtualRouter hostname bug

### DIFF
--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/dhcp/VirtualRouterDhcpBackend.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/dhcp/VirtualRouterDhcpBackend.java
@@ -68,6 +68,17 @@ public class VirtualRouterDhcpBackend extends AbstractVirtualRouterBackend imple
                 e.setNetmask(struct.getNetmask());
                 e.setDnsDomain(struct.getDnsDomain());
                 e.setHostname(struct.getHostname());
+
+                if (e.isDefaultL3Network()) {
+                    if (e.getHostname() == null) {
+                        e.setHostname(e.getIp().replaceAll("\\.", "-"));
+                    }
+
+                    if (e.getDnsDomain() != null) {
+                        e.setHostname(String.format("%s.%s", e.getHostname(), e.getDnsDomain()));
+                    }
+                }
+
                 VmNicInventory vrNic = CollectionUtils.find(vr.getVmNics(), new Function<VmNicInventory, VmNicInventory>() {
                     @Override
                     public VmNicInventory call(VmNicInventory arg) {


### PR DESCRIPTION
Hostname in VirtualRouter dhcp is not generated.

For zxwing/premium#1271