### PR TITLE
fix ut from V0.6

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -136,6 +136,9 @@ public class VmInstanceBase extends AbstractVmInstance {
                 CheckVmStateOnHypervisorReply r = reply.castReply();
                 String state = r.getStates().get(self.getUuid());
                 self = dbf.reload(self);
+                if (state == null) {
+                    changeVmStateInDb(VmInstanceStateEvent.unknown);
+                }
                 if (VmInstanceState.Running.toString().equals(state)) {
                     self.setHostUuid(hostUuid);
                     changeVmStateInDb(VmInstanceStateEvent.running);


### PR DESCRIPTION
这种情况是：host收到了check vm状态的请求，但在本机暂时找不到vm，（ut就造了一种找不到的情况），所以返回null。此时mn应该装vm状态置为unknow